### PR TITLE
Only run analytics if the last number of the app version is 0

### DIFF
--- a/src/CTime2/App.xaml.cs
+++ b/src/CTime2/App.xaml.cs
@@ -306,7 +306,8 @@ namespace CTime2
         public override bool IsAnalyticsServiceEnabled()
         {
             return base.IsAnalyticsServiceEnabled() &&
-                   Package.Current.Id.Version.ToVersion() != new Version("9999.9999.9999.0");
+                   Package.Current.Id.Version.ToVersion() != new Version("9999.9999.9999.0") &&
+                   Package.Current.Id.Version.ToVersion().Revision == 0;
         }
         #endregion
 


### PR DESCRIPTION
Tt is something else if microsoft tries something out, but it has to be 0 for the store.
This means we won't get anylthics from random microsoft tryouts.